### PR TITLE
Change the way .zvmrc files are used

### DIFF
--- a/zvm
+++ b/zvm
@@ -237,10 +237,15 @@ function _zvm_dir() {
   version="$1"
 
   if [[ -z $version ]]; then
-    if [[ -f "${PWD}/.zvmrc" ]]; then
-      echo $(cat "${PWD}/.zvmrc")
-      return
-    fi
+    local filename=".zvmrc"
+    while [[ $(realpath $filename) != '/.zvmrc' ]]; do
+      if [[ -f $filename && -r $filename ]]; then
+        echo $(cat $filename)
+        return
+      fi
+
+      filename="../$filename"
+    done
 
     [[ -z $quiet ]] && echo $(color yellow "No version set for $PWD. Run \`zvm use <version>\`")
     return 1

--- a/zvm-shell-integration.zsh
+++ b/zvm-shell-integration.zsh
@@ -19,10 +19,27 @@ manpath=(
   $manpath
 )
 
+typeset -g ZVM_GLOBAL_VERSION
+
 autoload -U add-zsh-hook
 load-zvmrc() {
-  if [[ -n ${ZVM_AUTO_USE} && -f .zvmrc && -r .zvmrc ]]; then
-    zvm use
+  if [[ -z $ZVM_AUTO_USE ]]; then
+    return
+  fi
+
+  version=$(zvm dir --quiet 2>&1)
+  if [[ -n $version ]]; then
+    if [[ $version != $(zvm current) ]]; then
+      ZVM_GLOBAL_VERSION=$(zvm current)
+      zvm use $version
+    fi
+
+    return
+  fi
+
+  if [[ -n $ZVM_GLOBAL_VERSION ]]; then
+    zvm use ${ZVM_GLOBAL_VERSION}
+    ZVM_GLOBAL_VERSION=''
   fi
 }
 add-zsh-hook chpwd load-zvmrc


### PR DESCRIPTION
The `zvm dir` command now searches recursively up the directory tree from `$PWD`, and checks for the existence of `.zvmrc` files anywhere in the tree. This means that `zvm dir` can be run anywhere within the project directory, rather than just from its root.

As well as this, the auto_use hook now uses `zvm dir` rather than checking for `.zvmrc` files itself, so that changing directory into any path within a projects tree will automatically pick up the `.zvmrc` file in the root directory and switch to the correct version.

The hook also now remembers the previous version, and so as soon as the current directory changes to somewhere outside of the project tree, the version that was selected before entering that project is re-enabled.