### PR TITLE
Use localoptions with err_exit

### DIFF
--- a/zvm
+++ b/zvm
@@ -369,7 +369,7 @@ function _zvm_install() {
   fi
 
   # Make sure we exit if we hit an error
-  setopt ERR_EXIT
+  setopt localoptions ERR_EXIT
 
   # Clear the logfile
   cat /dev/null >! $logfile


### PR DESCRIPTION
The option err_exit works globally and causes zvm to exit at some point after successful installation. The patch solves this